### PR TITLE
feat(order): persist and expose OrderProgress (OS-06)

### DIFF
--- a/services/order-service/src/main/java/com/oms/orderservice/domain/model/Order.java
+++ b/services/order-service/src/main/java/com/oms/orderservice/domain/model/Order.java
@@ -33,6 +33,10 @@ public class Order {
     @Column(nullable = false)
     private OrderStatus status;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "progress", nullable = false)
+    private OrderProgress progress;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
 
@@ -48,7 +52,7 @@ public class Order {
         Order order = new Order();
         order.createdAt = Instant.now();
         order.status = OrderStatus.PENDING;
-
+        order.progress = OrderProgress.ORDER_ACCEPTED;
         for (OrderItem item : rawItems) {
             order.addItem(item);
         }
@@ -87,88 +91,3 @@ public class Order {
         // Optional: persist failure reason in a column later
     }
 }
-
-
-//package com.oms.orderservice.domain.model;
-//
-//import jakarta.persistence.*;
-//import lombok.Getter;
-//
-//import java.math.BigDecimal;
-//import java.time.Instant;
-//import java.util.ArrayList;
-//import java.util.List;
-//import java.util.UUID;
-//
-//@Entity
-//@Table(name = "orders")
-//@Getter
-//public class Order {
-//
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.UUID)
-//    @Column(name = "order_id", updatable = false, nullable = false)
-//    private UUID id;
-//
-//    @OneToMany(
-//            mappedBy = "order",
-//            cascade = CascadeType.ALL,
-//            orphanRemoval = true
-//    )
-//    private List<OrderItem> items = new ArrayList<>();
-//
-//    @Column(name = "total_amount", nullable = false)
-//    private BigDecimal totalAmount;
-//
-//    @Enumerated(EnumType.STRING)
-//    @Column(nullable = false)
-//    private OrderStatus status;
-//
-//    @Column(name = "created_at", nullable = false, updatable = false)
-//    private Instant createdAt;
-//
-//    protected Order() {
-//        // JPA only
-//    }
-//
-//    /* ========= Factory ========= */
-//
-//    public static Order create(List<OrderItem> rawItems) {
-//        if (rawItems == null || rawItems.isEmpty()) {
-//            throw new IllegalArgumentException("Order must contain at least one item");
-//        }
-//
-//        Order order = new Order();
-//        order.createdAt = Instant.now();
-//        order.status = OrderStatus.PENDING;
-//
-//        for (OrderItem item : rawItems) {
-//            order.addItem(item);
-//        }
-//
-//        order.recalculateTotal();
-//        return order;
-//    }
-//
-//    /* ========= Domain behavior ========= */
-//
-//    private void addItem(OrderItem item) {
-//        item.attachTo(this);   // enforce invariant
-//        this.items.add(item);
-//    }
-//
-//    private void recalculateTotal() {
-//        this.totalAmount = items.stream()
-//                .map(OrderItem::totalPrice)
-//                .reduce(BigDecimal.ZERO, BigDecimal::add);
-//    }
-//
-//    private void markCompleted(){
-//        this.status = OrderStatus.CONFIRMED;
-//
-//    }
-//    private void markFailed(String reason){
-//        this.status = OrderStatus.FAILED;
-//
-//    }
-//}


### PR DESCRIPTION
- Added OrderProgress field to Order entity
- Persisted as enum string
- Initialized at creation time
- No saga logic or messaging changes
Closes #7 