### PR TITLE
OS-03: Add optimistic locking to Order entity 

### DIFF
--- a/services/order-service/src/main/java/com/oms/orderservice/domain/model/Order.java
+++ b/services/order-service/src/main/java/com/oms/orderservice/domain/model/Order.java
@@ -19,6 +19,10 @@ public class Order {
     @Column(name = "order_id", updatable = false, nullable = false)
     private UUID id;
 
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
+
     @OneToMany(
             mappedBy = "order",
             cascade = CascadeType.ALL,


### PR DESCRIPTION
What does this PR do?
- Adds optimistic locking to Order aggregate using @Version

Why is this needed?
- Prevents lost updates during concurrent saga, API, and outbox operations

What is intentionally NOT included?
- No business logic changes
- No retry handling
- No saga behavior
Closes #3 