### PR TITLE
OS-05: Redis-backed idempotency for order creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,12 @@ services:
     volumes:
       - inventory_db_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7
+    container_name: redis
+    ports:
+      - "6379:6379"
+
 
 volumes:
   order_db_data:

--- a/services/order-service/src/main/resources/application.properties
+++ b/services/order-service/src/main/resources/application.properties
@@ -74,3 +74,9 @@ spring.kafka.consumer.properties.isolation.level=read_committed
 # LISTENER CONTAINER (Manual ACK)
 # ===============================
 spring.kafka.listener.ack-mode=manual
+
+#Redis config
+
+spring.data.redis.host=redis
+spring.data.redis.port=6379
+spring.data.redis.timeout=2s


### PR DESCRIPTION
## What
Adds Redis as shared infrastructure and configures order-service
to support idempotent order creation.

## Why
Client retries in distributed systems can lead to duplicate orders.
Redis-backed idempotency ensures safe retries without data duplication.

## How
- Added Redis to docker-compose
- Configured order-service Redis connection

## Scope
- Infrastructure: Redis
- Service: Order Service only

## Notes
Redis is used strictly for coordination/idempotency, not business state.
Closes #5 