### PR TITLE
fix: remove unused lombok dependency from event-contracts

### DIFF
--- a/backend/services/event-contracts/src/main/java/com/oms/eventcontracts/events/PaymentRefundedEvent.java
+++ b/backend/services/event-contracts/src/main/java/com/oms/eventcontracts/events/PaymentRefundedEvent.java
@@ -1,16 +1,9 @@
 package com.oms.eventcontracts.events;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
 public class PaymentRefundedEvent {
 
     private UUID orderId;
@@ -27,8 +20,7 @@ public class PaymentRefundedEvent {
             UUID paymentId,
             BigDecimal amount,
             String reason,
-            Instant refundedAt
-    ) {
+            Instant refundedAt) {
         this.orderId = orderId;
         this.paymentId = paymentId;
         this.amount = amount;


### PR DESCRIPTION
### What this PR does
This PR resolves the compilation failure in the CI/CD pipeline (`Backend CI` and `CodeQL Analysis`).

### Why it was failing
The compilation failed with `package lombok does not exist` in `PaymentRefundedEvent.java` because the `event-contracts` module did not have the Lombok dependency declared in its `pom.xml`. Since this module is a clean POJO-only package, and the class already implements the necessary constructors and getters manually, we can simply remove the unused Lombok annotations and imports.

### Changes
* Removed the unused Lombok imports (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) from `PaymentRefundedEvent.java`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Completed internal code maintenance updates to improve code organization and maintainability without affecting end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->