### PR TITLE
fix: inject SimpleMeterRegistry spy in OrderCommandServiceTest

### DIFF
--- a/backend/services/order-service/src/test/java/com/oms/orderservice/application/OrderCommandServiceTest.java
+++ b/backend/services/order-service/src/test/java/com/oms/orderservice/application/OrderCommandServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
@@ -32,6 +33,9 @@ class OrderCommandServiceTest {
 
     @Mock
     private ObjectMapper objectMapper;
+
+    @Spy
+    private io.micrometer.core.instrument.MeterRegistry meterRegistry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
 
     @InjectMocks
     private OrderCommandService orderCommandService;


### PR DESCRIPTION
### What this PR does
This PR fixes a `NullPointerException` occurring in `OrderCommandServiceTest` during unit test execution.

### Why it was failing
The `OrderCommandService` class was recently updated to track metrics using Micrometer's `MeterRegistry`. In `OrderCommandServiceTest`, Mockito's `@InjectMocks` was injecting a `null` reference for the `MeterRegistry` dependency because it wasn't defined in the test class. This resulted in an NPE when registering metrics in the constructor of `OrderCommandService`.

### Changes
* Declared a `@Spy` of `SimpleMeterRegistry` inside `OrderCommandServiceTest` and registered it to be injected into `OrderCommandService`. This ensures that metrics can be registered and incremented during tests without errors.
