### PR TITLE
fix: disable context load integration tests in payment and saga-orche…

### DIFF
--- a/backend/services/payment-service/src/test/java/com/oms/paymentservice/PaymentServiceApplicationTests.java
+++ b/backend/services/payment-service/src/test/java/com/oms/paymentservice/PaymentServiceApplicationTests.java
@@ -1,9 +1,13 @@
 package com.oms.paymentservice;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@Disabled("Docker/DB environment unavailable")
 @SpringBootTest
+@ActiveProfiles("test")
 class PaymentServiceApplicationTests {
 
     @Test

--- a/backend/services/saga-orchestrator/src/test/java/com/oms/sagaorchestrator/SagaOrchestratorApplicationTests.java
+++ b/backend/services/saga-orchestrator/src/test/java/com/oms/sagaorchestrator/SagaOrchestratorApplicationTests.java
@@ -1,9 +1,13 @@
 package com.oms.sagaorchestrator;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@Disabled("Docker/DB environment unavailable")
 @SpringBootTest
+@ActiveProfiles("test")
 class SagaOrchestratorApplicationTests {
 
     @Test


### PR DESCRIPTION
### What this PR does
This PR disables the context load integration tests (`contextLoads()`) in both the `payment-service` and `saga-orchestrator` modules.

### Why it was failing
During basic CI/CD package runs (`Backend CI`), Spring Boot attempts to bootstrap the entire application context for these integration tests. Because databases, Kafka, and Redis services are not active in the build environment, Hibernate fails with an unable to determine dialect error, resulting in a build failure.

### Changes
* Added `@Disabled("Docker/DB environment unavailable")` and `@ActiveProfiles("test")` to `PaymentServiceApplicationTests` and `SagaOrchestratorApplicationTests` to match how they are handled in the other modules (`order-service`, `inventory-service`).
