### PR TITLE
fix: upgrade maven-dependency-submission-action to v4

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,6 +32,6 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      uses: advanced-security/maven-dependency-submission-action@v4
       with:
         directory: backend


### PR DESCRIPTION
### What this PR does
This PR upgrades the `maven-dependency-submission-action` dependency in our CI workflow to version `v4`.

### Why it was failing
The previous version tag (`@571e99aab1...` from 2023) was failing with `TypeError: Cannot read properties of undefined (reading 'forEach')` when running on multi-module maven builds under the updated GitHub runner environment.

### Changes
* Upgraded `advanced-security/maven-dependency-submission-action` from a legacy commit hash to the stable `@v4` version tag.
